### PR TITLE
Update MDIO pins in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ We're generating the 50MHz RMII clock on the RP2040 instead of getting it from t
 | RX1 | RX0 + 1 | 7 |
 | nINT / RETCLK | 21/23/24/25 | 21 |
 | CRS | RX0 + 2 | 8 |
-| MDIO | any GPIO | 16 |
-| MDC | MDIO + 1 | 17 |
+| MDIO | any GPIO | 14 |
+| MDC | MDIO + 1 | 15 |
 | VCC | 3V3 | |
 | GND | GND | |
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ We're generating the 50MHz RMII clock on the RP2040 instead of getting it from t
 | RX1 | RX0 + 1 | 7 |
 | nINT / RETCLK | 21/23/24/25 | 21 |
 | CRS | RX0 + 2 | 8 |
-| MDIO | any GPIO | 14 |
-| MDC | MDIO + 1 | 15 |
+| MDIO | any GPIO | 16 |
+| MDC | MDIO + 1 | 17 |
 | VCC | 3V3 | |
 | GND | GND | |
 

--- a/examples/httpd/main.c
+++ b/examples/httpd/main.c
@@ -37,7 +37,7 @@ int main() {
       0,    // pio SM:         0 and 1
       6,    // rx pin start:   6, 7, 8    => RX0, RX1, CRS
       10,   // tx pin start:   10, 11, 12 => TX0, TX1, TX-EN
-      16,   // mdio pin start: 14, 15   => ?MDIO, MDC
+      14,   // mdio pin start: 14, 15   => ?MDIO, MDC
       21,   // rmii clock:     21, 23, 24 or 25 => RETCLK
       NULL, // MAC address (optional - NULL generates one based on flash id)
   };

--- a/src/include/rmii_ethernet/netif.h
+++ b/src/include/rmii_ethernet/netif.h
@@ -27,6 +27,7 @@ struct netif_rmii_ethernet_config {
     .rx_pin_start = 6, \
     .tx_pin_start = 10, \
     .mdio_pin_start = 14, \
+    .retclk_pin = 21, \
     .mac_addr = NULL \
 }
 


### PR DESCRIPTION
The MDIO pin numbers were changed from upstream in code, but the readme was not updated.
This confused me for quite a while, as the nINT pin was updated so I assumed the readme was correct